### PR TITLE
Update Q001-010.md

### DIFF
--- a/Optique/001-Ondes/Q001-010.md
+++ b/Optique/001-Ondes/Q001-010.md
@@ -8,4 +8,4 @@
 
 ### Réponse
 
-Un photon à 500 nm a une énergie de 2 eV (ou $1.6 \times 10^{-19}J$), donc $ 1 \text{ pW} / \left( 2 \text{ eV/photon} \right)  = 3 \times 10^{6} \text{photon/s}$ ou 3 photons par 1 µs.
+Un photon à 500 nm a une énergie de 2.48 eV (ou $3.2 \times 10^{-19}J$), donc $ 1 \text{ pW} / \left( 2.48 \text{ eV/photon} \right)  = 3 \times 10^{6} \text{photon/s}$ ou 3 photons par 1 µs.


### PR DESCRIPTION
Même résultat mais précision sur les valeurs en eV et joules. Correction sur la conversion 2 eV en Joule, il manquait un facteur 2.